### PR TITLE
 fixing rerun of build as oc process on buildconfig starts build as well

### DIFF
--- a/playbooks/nepthys-deploy/tasks/main.yaml
+++ b/playbooks/nepthys-deploy/tasks/main.yaml
@@ -24,9 +24,6 @@
     -p GENERIC_SECRET={{ GENERIC_SECRET | default('secret101', true) }}
     | oc apply --namespace {{ NEPTHYS_APPLICATION_NAMESPACE }} -f -
 
-- name: "Start nepthys-job Build"
-  command: oc start-build --namespace {{ NEPTHYS_APPLICATION_NAMESPACE }} nepthys-job
-
 - name: "Check if required Secret 'nepthys-secret' exists"
   command: "oc get secret --namespace {{ NEPTHYS_APPLICATION_NAMESPACE }} nepthys-secret"
   ignore_errors: true


### PR DESCRIPTION
PR fixes duplication of build runs.
- `oc process buildconfig ...` : starts a build.