### PR TITLE
pipenv updates are not needed

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -11,9 +11,6 @@ runtime_environments:
     recommendation_type: latest
 
 managers:
-  - name: update
-    configuration:
-      labels: [bot]
   - name: info
   - name: version
     configuration:


### PR DESCRIPTION
pipenv updates are not needed
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Fixes: #26 

## This introduces a breaking change

- [x] No

## Description

Not a python project! dont need package updates.