### PR TITLE
don't ignore the thoth/nepthys/__init__.py file changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ clones
 
 thoth-station.github.io/
 thoth/
+!thoth/nepthys


### PR DESCRIPTION
updated nepthys app with python3.8 support
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies
kebechet failing to help with release.
```
git.exc.GitCommandError: Cmd('git') failed due to: exit code(1)
  cmdline: git add ./thoth/nepthys/__init__.py
  stderr: 'The following paths are ignored by one of your .gitignore files:
thoth
```