### PR TITLE
unignore __init__.py explicitly under thoth/nepthys dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,5 +105,8 @@ venv.bak/
 clones
 
 thoth-station.github.io/
-thoth/
-!thoth/nepthys
+!thoth/
+thoth/*
+!thoth/nepthys/
+thoth/nepthys/*
+!thoth/nepthys/__init__.py


### PR DESCRIPTION
unignore __init__.py explicitly under thoth/nepthys dir
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: #58 

