### PR TITLE
Use a single list of repos to generate and commit changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Nepthys
 
 This simple bot iterates over Thoth repositories and updates documentation.
 
-Just run ``clone_repos.sh`` script, it will produce documentation for all the
+Just run ``create_docs.sh`` script, it will produce documentation for all the
 libraries inside ``thoth`` directory.
 
 

--- a/create_docs.sh
+++ b/create_docs.sh
@@ -5,10 +5,11 @@ set -ex
 die() { echo "$*" 1>&2 ; exit 1; }
 
 workdir=$PWD
+repo_list="thamos adviser analyzer common lab package-extract python solver storages investigator messaging kebechet"
 
 rm -rf clones # thoth
 mkdir -p thoth/
-for repo in thamos adviser analyzer common lab package-extract python solver storages investigator messaging kebechet
+for repo in $repo_list
 do
     git clone --depth 1 https://github.com/thoth-station/${repo}.git clones/${repo}
     # Copy _templates to each repo for Google analytics functionality.
@@ -55,7 +56,7 @@ if  [[ $GITHUB_COMMIT = "1" ]]; then
     git clone --depth 1 git@github.com:thoth-station/thoth-station.github.io.git
     rm -rf thoth-station.github.io/docs/developers/
 
-    for repo in thamos adviser analyzer common lab package-extract python solver storages investigator messaging
+    for repo in $repo_list
     do
         mkdir -p thoth-station.github.io/assets/${repo}/
         mv thoth/${repo}/_modules/  thoth/${repo}/modules/|| true


### PR DESCRIPTION
## Related Issues and Dependencies

Related to: https://github.com/thoth-station/kebechet/issues/944
Completes the intended change from #76 

## Description

The list of repos to work with was duplicated, which means it was also prone to inconsistencies.

This PR changes to a single list of repos for the docs generation and repo commit steps.

Also fixing the ref to the script name in the README.