### PR TITLE
Point the tag badge to the list of tags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Nepthys
 -------
 
 .. image:: https://img.shields.io/github/v/tag/thoth-station/nepthys?style=plastic
-  :target: https://github.com/thoth-station/nepthys/releases
+  :target: https://github.com/thoth-station/nepthys/tags
   :alt: GitHub tag (latest by date)
 
 .. image:: https://quay.io/repository/thoth-station/nepthys/status


### PR DESCRIPTION
This is to update the URL in the first badge in the readme to point to the tags list (as advertised) instead of releases (which don't exist in this repo).