### PR TITLE
Include gcc-c++ compiler into nepthys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,11 @@ COPY _templates /home/user/_templates
 
 # Install any needed packages
 RUN \
-    dnf install -y --setopt=tsflags=nodocs hub python36 python3-pip gcc redhat-rpm-config python3-devel which graphviz &&\
+    dnf install -y --setopt=tsflags=nodocs hub \
+      python36 python3-pip python3-devel \
+      gcc gcc-c++ \
+      redhat-rpm-config which graphviz &&\
+
     pip3 install pipenv &&\
     mkdir -p /home/user/.ssh &&\
     chmod a+wrx -R /etc/passwd /home/user


### PR DESCRIPTION
Include gcc-c++ compiler into nepthys
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/nepthys/issues/80#issuecomment-1000430683

## Description

Kebechet's fasttext package which requires gcc-c++ compiler for build