### PR TITLE
Build kebechet from the subdir kebechet and not from thoth

### DIFF
--- a/create_docs.sh
+++ b/create_docs.sh
@@ -25,6 +25,8 @@ do
         # Thamos requires OpenAPI specification from User API.
         git clone --depth 1 https://github.com/thoth-station/user-api.git ../user-api
         pipenv run sphinx-apidoc -o docs/source thamos --implicit-namespaces
+    elif [[ "$repo" = "kebechet" ]]; then
+        pipenv run sphinx-apidoc -o docs/source kebechet --implicit-namespaces
     else
         pipenv run sphinx-apidoc -o docs/source thoth --implicit-namespaces
     fi


### PR DESCRIPTION
Build kebechet from the subdir kebechet and not from thoth
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/nepthys/issues/80#issuecomment-1000481920
